### PR TITLE
TBL subsystem

### DIFF
--- a/ground/ground.ino
+++ b/ground/ground.ino
@@ -468,6 +468,16 @@ int parseCICommand(char *s) {
   } else if (isCmd(tok_start[0], tok_len[0], "STOP")) {
       cmd_data[0] = 0;
       cmd = CI_CMD_EXT_STOP;
+  } else if (isCmd(tok_start[0], tok_len[0], "SET")) {
+    cmd = CI_CMD_EXT_SET;
+    if (0 != tok_len[1]) {
+      v1 = parseUint8(tok_start[1], tok_len[1]);
+      cmd_data[0] = v1;
+    }
+    if (0 != tok_len[2]) {
+      v2 = parseUint8(tok_start[2], tok_len[2]);
+      cmd_data[3] = v2;
+    }
   }
 
   if (0 == cmd) {

--- a/libraries/CiC/Makefile
+++ b/libraries/CiC/Makefile
@@ -24,11 +24,12 @@ build/%.o: %.c $(HEADERS)
 build/test_%: test_%.c $(OBJECTS)
 	$(CC) $(CFLAGS) $< $(OBJECTS) -Wall $(LIBS) -o $@
 
-test: build/test_to build/test_evt build/test_com build/test_tmr
+test: build/test_to build/test_evt build/test_com build/test_tmr build/test_tbl
 	./build/test_to
 	./build/test_evt
 	./build/test_com
 	./build/test_tmr
+	./build/test_tbl
 
 clean:
 	-rm -f $(OBJDIR)/*.o $(TARGET)

--- a/libraries/CiC/README.md
+++ b/libraries/CiC/README.md
@@ -29,6 +29,7 @@ Consider this more of an educational project.
   * `to` *telemetry* provides an interface for recording parameters and their values, packaging up a packet to send to mission control.
   * `ci` *command ingestion* processes commands and maps them to mission specific functions.
   * `tmr` *timer* provides for triggering events on a timed schedule
+  * `tbl` *table* provides persistent storage of runtime adjustable configuration variables.
 
 ## Usage
 

--- a/libraries/CiC/src/ci.h
+++ b/libraries/CiC/src/ci.h
@@ -3,7 +3,6 @@
 
 #include "evt.h"
 
-// TODO: These commands should be mission specific.
 #define CI_CMD_NOOP  1
 #define CI_CMD_CLEAR 2
 #define CI_CMD_BOOM  3

--- a/libraries/CiC/src/tbl.c
+++ b/libraries/CiC/src/tbl.c
@@ -1,0 +1,96 @@
+#include "tbl.h"
+#include <string.h>
+
+void TBL_init(TBL_t *tbl, TBL_save_func_t save, TBL_load_func_t load)
+{
+    tbl->save = save;
+    tbl->load = load;
+    memset(tbl->buf, 0, sizeof(tbl->buf));
+}
+
+int TBL_set_default(TBL_t *tbl, uint8_t tbl_var, uint16_t value)
+{
+    if (TBL_MAGIC == tbl->buf[0]) {
+        return 0;
+    }
+
+    if (tbl_var == 0 || tbl_var > TBL_SIZE) {
+        return ERR_TBL_VAR;
+    }
+
+    tbl->buf[tbl_var] = value;
+
+    return 0;
+}
+
+int TBL_set(TBL_t *tbl, uint8_t tbl_var, uint16_t value)
+{
+    if (tbl_var == 0 || tbl_var > TBL_SIZE) {
+        return ERR_TBL_VAR;
+    }
+
+    if (tbl->buf[0] != TBL_MAGIC) {
+        int loaded = TBL_load(tbl);
+        if (0 != loaded) {
+            return loaded;
+        }
+    }
+
+    tbl->buf[tbl_var] = value;
+
+    return TBL_save(tbl);
+}
+
+int TBL_get(TBL_t *tbl, uint8_t tbl_var, uint16_t *value)
+{
+    int loaded = TBL_load(tbl);
+    if (ERR_TBL_LOADED != loaded && 0 != loaded) {
+        return loaded;
+    }
+
+    if (tbl_var == 0 || tbl_var > TBL_SIZE) {
+        return ERR_TBL_VAR;
+    }
+
+    *value = tbl->buf[tbl_var];
+
+    return 0;
+}
+
+int TBL_save(TBL_t *tbl)
+{
+    if (TBL_MAGIC != tbl->buf[0]) {
+        return ERR_TBL_NOT_LOADED;
+    }
+
+    return tbl->save(tbl->buf, sizeof(tbl->buf));
+}
+
+int TBL_load(TBL_t *tbl)
+{
+    uint16_t tmp_buffer[TBL_SIZE+1];
+
+    if (TBL_MAGIC == tbl->buf[0]) {
+        // We've already been loaded
+        return ERR_TBL_LOADED;
+    }
+
+    if (0 == tbl->load || 0 == tbl->save) {
+        return ERR_TBL_INIT;
+    }
+
+    int loaded = tbl->load(tmp_buffer, sizeof(tmp_buffer));
+    if (0 != loaded) {
+        return loaded;
+    }
+
+    if (TBL_MAGIC == tmp_buffer[0]) {
+        // The data we loaded is valid, put it into place.
+        memcpy(tbl->buf, tmp_buffer, sizeof(tbl->buf));
+    } else {
+        // No saved data yet, we can just keep our defaults by marking magic.
+        tbl->buf[0] = TBL_MAGIC;
+    }
+
+    return 0;
+}

--- a/libraries/CiC/src/tbl.h
+++ b/libraries/CiC/src/tbl.h
@@ -3,20 +3,58 @@
 #include <stdint.h>
 #include <stddef.h>
 
+// TBL_SIZE defines the maximum number of table variables.
 #define TBL_SIZE 8
+
+// TBL_MAGIC is a constant stored along with the persistent data to help ensure the data 
+// is not just random noise.
+// TODO: Versioning
 #define TBL_MAGIC 0xF0AA
 
-#define ERR_TBL_INIT -3
-#define ERR_TBL_LOADED -4
+#define ERR_TBL_INIT       -3
+#define ERR_TBL_LOADED     -4
 #define ERR_TBL_NOT_LOADED -5
-#define ERR_TBL_VAR -6
+#define ERR_TBL_VAR        -6
 
+/*
+ * TBL_save_func_t defines a function pointer for the user to define how
+ * persistent TBL data should be stored.
+ * 
+ * Implementers are expected to take the data and save it somewhere persistent.
+ * 
+ * @param data Pointer to data to save
+ * @param data_len Length of data to save
+ * 
+ * @returns 0 on success
+ */
 typedef int (*TBL_save_func_t)(const void *data, size_t data_len);
+
+/*
+ * TBL_load_func_t defines a function pointer for the user to define how to load
+ * persistent TBL data.
+ * 
+ * Implementers are expected to write the data to the provided destination not
+ * to exceed the provided buffer size.
+ * 
+ * @param data Destination to load the data to.
+ * @param data_len Buffer size to load.
+ * 
+ * @returns 0 on success
+ */
 typedef int (*TBL_load_func_t)(void *data, size_t data_len);
 
-// TBL_t defines the Table Subsystem. 
-// The system is for storing a persistent table of data useful for configuration
-// variables that are expected to survive a reboot.
+/* 
+ * TBL_t defines the Table Subsystem. 
+ * The system is for storing a persistent table of data useful for configuration
+ * variables that are expected to survive a reboot.
+ * 
+ * The TBL consists of a number of user defined variables represented by a
+ * uint8_t. Each of these variables can store a uint16_t.
+ *
+ * The actual saving and loading of the data is abstracted out so as to be
+ * hardware agnostic.
+ * See also TBL_save_func_t and TBL_load_func_t
+ */
 typedef struct {
     uint16_t buf[TBL_SIZE+1];
 
@@ -24,9 +62,48 @@ typedef struct {
     TBL_load_func_t load; 
 } TBL_t;
 
+/*
+ * TBL_init initializes the table structure with the provided save and load
+ * functions.
+ *
+ * See also TBL_save_func_t, TBL_load_func_t
+ */
 void TBL_init(TBL_t *tbl, TBL_save_func_t save, TBL_load_func_t load);
 
-int TBL_set(TBL_t *tbl, uint8_t tbl_var, uint16_t value);
+/*
+ * TBL_set_defaults sets a default value of the specified tbl variable.
+ *
+ * If the variable already exists in persistent storage the value will not
+ * be replaced. Calling this function will trigger no loading or saving of 
+ * any data.
+ *
+ * @param tbl Table instance
+ * @param tbl_var Specific table variable to set
+ * param value Value to set
+ *
+ */
 int TBL_set_default(TBL_t *tbl, uint8_t tbl_var, uint16_t value);
+
+/*
+ * TBL_set sets the value of the specified tbl variable.
+ *
+ * The new value will be immediately written to persistent storage.
+ *
+ * @param tbl Table instance
+ * @param tbl_var Specific table variable to set
+ * param value Value to set
+ *
+ */
+int TBL_set(TBL_t *tbl, uint8_t tbl_var, uint16_t value);
+
+/*
+ * TBL_get retrieves the value of the specified tbl variable.
+ *
+ * @param tbl Table instance
+ * @param tbl_var Specific table variable to get
+ * param value Pointer to store the value to
+ *
+ */
 int TBL_get(TBL_t *tbl, uint8_t tbl_var, uint16_t *value);
+
 #endif

--- a/libraries/CiC/src/tbl.h
+++ b/libraries/CiC/src/tbl.h
@@ -11,8 +11,8 @@
 #define ERR_TBL_NOT_LOADED -5
 #define ERR_TBL_VAR -6
 
-typedef int (*TBL_save_func_t)(uint16_t *data, size_t data_len);
-typedef int (*TBL_load_func_t)(uint16_t *data, size_t data_len);
+typedef int (*TBL_save_func_t)(const void *data, size_t data_len);
+typedef int (*TBL_load_func_t)(void *data, size_t data_len);
 
 // TBL_t defines the Table Subsystem. 
 // The system is for storing a persistent table of data useful for configuration

--- a/libraries/CiC/src/tbl.h
+++ b/libraries/CiC/src/tbl.h
@@ -1,0 +1,32 @@
+#ifndef TBL_h
+#define TBL_h
+#include <stdint.h>
+#include <stddef.h>
+
+#define TBL_SIZE 8
+#define TBL_MAGIC 0xF0AA
+
+#define ERR_TBL_INIT -3
+#define ERR_TBL_LOADED -4
+#define ERR_TBL_NOT_LOADED -5
+#define ERR_TBL_VAR -6
+
+typedef int (*TBL_save_func_t)(uint16_t *data, size_t data_len);
+typedef int (*TBL_load_func_t)(uint16_t *data, size_t data_len);
+
+// TBL_t defines the Table Subsystem. 
+// The system is for storing a persistent table of data useful for configuration
+// variables that are expected to survive a reboot.
+typedef struct {
+    uint16_t buf[TBL_SIZE+1];
+
+    TBL_save_func_t save; 
+    TBL_load_func_t load; 
+} TBL_t;
+
+void TBL_init(TBL_t *tbl, TBL_save_func_t save, TBL_load_func_t load);
+
+int TBL_set(TBL_t *tbl, uint8_t tbl_var, uint16_t value);
+int TBL_set_default(TBL_t *tbl, uint8_t tbl_var, uint16_t value);
+int TBL_get(TBL_t *tbl, uint8_t tbl_var, uint16_t *value);
+#endif

--- a/libraries/CiC/test/test_tbl.c
+++ b/libraries/CiC/test/test_tbl.c
@@ -14,24 +14,24 @@ void clear()
     memset(test_buffer, 0, sizeof(test_buffer));
 }
 
-int save(uint16_t *data, size_t data_len)
+int save(const void *data, size_t data_len)
 {
     memcpy(test_buffer, data, data_len);
     return 0;
 }
 
-int load(uint16_t *data, size_t data_len)
+int load(void *data, size_t data_len)
 {
     memcpy(data, test_buffer, data_len);
     return 0;
 }
 
-int save_fail(uint16_t *data, size_t data_len)
+int save_fail(const void *data, size_t data_len)
 {
     return -1;
 }
 
-int load_fail(uint16_t *data, size_t data_len)
+int load_fail(void *data, size_t data_len)
 {
     return -1;
 }

--- a/libraries/CiC/test/test_tbl.c
+++ b/libraries/CiC/test/test_tbl.c
@@ -1,0 +1,143 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "minunit.h"
+#include "mock_arduino.h"
+#include "tbl.h"
+ 
+int tests_run = 0;
+
+uint16_t test_buffer[TBL_SIZE+1];
+
+void clear()
+{
+    memset(test_buffer, 0, sizeof(test_buffer));
+}
+
+int save(uint16_t *data, size_t data_len)
+{
+    memcpy(test_buffer, data, data_len);
+    return 0;
+}
+
+int load(uint16_t *data, size_t data_len)
+{
+    memcpy(data, test_buffer, data_len);
+    return 0;
+}
+
+int save_fail(uint16_t *data, size_t data_len)
+{
+    return -1;
+}
+
+int load_fail(uint16_t *data, size_t data_len)
+{
+    return -1;
+}
+
+static char * test_tbl_fail() {
+    TBL_t tbl;
+    clear();
+
+    TBL_init(&tbl, &save_fail, &load_fail);
+
+    int ret = TBL_set_default(&tbl, 1, 0);
+    mu_assert("set_default no error", ret == 0);
+
+    ret = TBL_get(&tbl, 1, 0);
+    mu_assert("get return error", ret == -1);
+
+    ret = TBL_set(&tbl, 1, 0);
+    mu_assert("set return errro", ret == -1);
+
+    return 0;
+}
+
+static char * test_tbl() {
+    TBL_t tbl;
+    clear();
+    TBL_init(&tbl, &save, &load);
+
+    uint16_t value = 0;
+    int ret = TBL_get(&tbl, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get 0 val", value == 0);
+
+    ret = TBL_set(&tbl, 1, 42);
+    mu_assert("set no error", ret == 0);
+
+    ret = TBL_get(&tbl, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get 0 val", value == 42);
+
+    // Now make sure it was actually saved
+    TBL_t tblB;
+    TBL_init(&tblB, &save, &load);
+    ret = TBL_get(&tblB, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get 0 val", value == 42);
+
+    return 0;
+}
+
+static char * test_tbl_default() {
+    TBL_t tbl;
+    clear();
+    TBL_init(&tbl, &save, &load);
+
+    uint16_t value = 0;
+
+    int ret = TBL_set_default(&tbl, 1, 255);
+    mu_assert("set_default no error", ret == 0);
+
+    ret = TBL_get(&tbl, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get default val", value == 255);
+
+    // It was just a default, shouldn't be saved
+    TBL_t tblB;
+    TBL_init(&tblB, &save, &load);
+    ret = TBL_get(&tblB, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get default 0 val", value == 0);
+
+    // Set a second value for real, which should save it all out
+    ret = TBL_set(&tbl, 2, 42);
+    mu_assert("get no error", ret == 0);
+
+    TBL_t tblC;
+    TBL_init(&tblC, &save, &load);
+    ret = TBL_get(&tblC, 1, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get default 0 val", value == 255);
+
+    ret = TBL_get(&tblC, 2, &value);
+    mu_assert("get no error", ret == 0);
+    mu_assert("get default 0 val", value == 42);
+
+    return 0;
+}
+
+static char * all_tests() {
+    mu_run_test(test_tbl_fail);
+    mu_run_test(test_tbl);
+    mu_run_test(test_tbl_default);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    char *result = all_tests();
+
+    if (result != 0) {
+        printf("test_tbl: %s\n", result);
+    }
+    else {
+        printf("test_tbl: passed\n");
+    }
+
+    printf("test_tbl: ran %d tests\n", tests_run);
+
+    return result != 0;
+}
+

--- a/libraries/Stubborn/src/stubborn.h
+++ b/libraries/Stubborn/src/stubborn.h
@@ -10,7 +10,8 @@
 #define CI_CMD_EXT_LT    7
 #define CI_CMD_EXT_BCK   8
 #define CI_CMD_EXT_FFWD  9
-#define CI_MAX_CMDS 11
+#define CI_CMD_EXT_SET   10
+#define CI_MAX_CMDS 10
 
 #define TO_PARAM_ERROR    1
 #define TO_PARAM_MILLIS   2 

--- a/rover/ci.ino
+++ b/rover/ci.ino
@@ -118,3 +118,17 @@ void handleCIStop(EVT_Event_t *e)
 
     changeSpeed(0, 0);
 }
+
+int handleCmdSet(uint8_t data[CI_MAX_DATA])
+{
+    uint8_t var = data[0];
+
+    uint16_t val = data[2] << 8 | data[3];
+
+    if (0 != TBL_set(&tbl, var, val)) {
+      Error(ERR_TBL_SET);
+      return CI_R_ERR_FAILED;
+    }
+
+    return CI_R_OK;
+}

--- a/rover/errors.h
+++ b/rover/errors.h
@@ -10,3 +10,5 @@
 #define ERR_COM_SEND 20
 #define ERR_CI_REGISTER 30
 #define ERR_TMR_ENQUEUE 40
+#define ERR_TBL_SET 45
+#define ERR_TBL_GET 46

--- a/rover/impact.ino
+++ b/rover/impact.ino
@@ -25,6 +25,16 @@ void handleImpactSensor(EVT_Event_t *e)
     return;
   }
 
+  uint16_t enabled = 0;
+
+  if (0 != TBL_get(&tbl, TBL_VAL_IMPACT_ENABLE, &enabled)) {
+    Error(ERR_TBL_GET);
+  }
+
+  if (0 == enabled) {
+    return;
+  }
+
   if (e != (EVT_Event_t *)&impactSensorEvent) {
     return;
   }

--- a/rover/memtbl.ino
+++ b/rover/memtbl.ino
@@ -1,0 +1,21 @@
+extern "C" {
+    #include "tbl.h"
+    #include "errors.h"
+    #include "avr/eeprom.h"
+}
+
+uint16_t EEMEM memtbl[TBL_SIZE+1];
+
+int saveTable(uint16_t *data, size_t data_len)
+{
+    // These are void* so the number of bytes is double because we are dealing in 2-byte words.
+    eeprom_write_block(data, (void *)memtbl, 2*data_len);
+    return 0;
+}
+
+int loadTable(uint16_t *data, size_t data_len)
+{
+    // These are void* so the number of bytes is double because we are dealing in 2-byte words.
+    eeprom_read_block(data, (const void *)memtbl, 2*data_len);
+    return 0;
+}

--- a/rover/memtbl.ino
+++ b/rover/memtbl.ino
@@ -6,16 +6,14 @@ extern "C" {
 
 uint16_t EEMEM memtbl[TBL_SIZE+1];
 
-int saveTable(uint16_t *data, size_t data_len)
+int saveTable(const void *data, size_t data_len)
 {
-    // These are void* so the number of bytes is double because we are dealing in 2-byte words.
-    eeprom_write_block(data, (void *)memtbl, 2*data_len);
+    eeprom_write_block(data, (void *)memtbl, data_len);
     return 0;
 }
 
-int loadTable(uint16_t *data, size_t data_len)
+int loadTable(void *data, size_t data_len)
 {
-    // These are void* so the number of bytes is double because we are dealing in 2-byte words.
-    eeprom_read_block(data, (const void *)memtbl, 2*data_len);
+    eeprom_read_block(data, (const void *)memtbl, data_len);
     return 0;
 }

--- a/rover/rover.ino
+++ b/rover/rover.ino
@@ -98,6 +98,9 @@ void setup() {
   if (0 != CI_register(&ci, CI_CMD_EXT_LT, &handleCmdLT)) {
     Error(ERR_CI_REGISTER);
   }
+  if (0 != CI_register(&ci, CI_CMD_EXT_SET, &handleCmdSet)) {
+    Error(ERR_CI_REGISTER);
+  }
 
   // Send initial TO broadcast and start sync schedule.
   handleSyncTO((EVT_Event_t *)&syncTOEvent);

--- a/rover/rover.ino
+++ b/rover/rover.ino
@@ -7,6 +7,7 @@ extern "C" {
 #include "com.h"
 #include "ci.h"
 #include "tmr.h"
+#include "tbl.h"
 }
 
 #include "events.h"
@@ -28,11 +29,14 @@ EVT_Event_t syncTOEvent = {EVT_TYPE_SYNC_TO};
 
 EVT_Event_t ciStopEvent = {EVT_TYPE_CI_STOP};
 
+#define TBL_VAL_IMPACT_ENABLE 1
+
 TO_t to   = {0};
 EVT_t evt = {0};
 TMR_t tmr = {0};
 COM_t com = {0};
-CI_t ci = {0};
+CI_t ci   = {0};
+TBL_t tbl = {0};
 
 void setup() {
   // put your setup code here, to run once:
@@ -50,6 +54,12 @@ void setup() {
   if (0 != TO_init(&to)) {
     Serial.println("FAIL: TO init");
     abort();
+  }
+
+  TBL_init(&tbl, &saveTable, &loadTable);
+
+  if (0 != TBL_set_default(&tbl, TBL_VAL_IMPACT_ENABLE, 1)) {
+    Error(ERR_TBL_SET);
   }
 
   rfmInit();


### PR DESCRIPTION
This PR introduces the TBL component which provides persistent storage of runtime adjustable configuration variables.

I discovered during testing that it would be helpful to selectively enable or disable features or otherwise tune the performance of the rover interactively rather than by uploading code. See [this thread](https://twitter.com/rhettford/status/1403155433653628930)

Using a command such as:

    -> SET 1 0

We can set or clear flags or other values to adjust the rover's performance at run-time without changing any code. Variables are defined as a uint8 and can store a uint16. For Stubborn, this variables are stored eeprom

See also https://teslabs.com/openplayer/docs/docs/prognotes/EEPROM%20Tutorial.pdf which I used as reference material.

This PR also rewrites the token parsing for the ground station. It become clear when I needed a command that had 2 variables rather than one that better token parsing was needed. It is now much more tolerant of stray whitespace. 

