### PR TITLE
Stubbornly straight ahead

### DIFF
--- a/rover/motor.ino
+++ b/rover/motor.ino
@@ -38,6 +38,11 @@ void changeSpeed(int A, int B)
 
 void setMotor(int motor, int speed) {
   int out = 0;
+  uint16_t bias = 0;
+
+  if (0 != TBL_get(&tbl, TBL_VAL_MOTOR_BIAS_A+motor, &bias)) {
+    Error(ERR_TBL_GET);
+  }
   
   if (speed > 0) {
     digitalWrite(motorPin1[motor], HIGH);
@@ -50,8 +55,13 @@ void setMotor(int motor, int speed) {
 
     out = -speed;
   }
+
+  if (out < bias) {
+    speed = 0;
+    bias = 0;
+  }
   
-  analogWrite(enablePin[motor], out);
+  analogWrite(enablePin[motor], out - bias);
 }
 
 void handleMotorSpeed(EVT_Event_t *e)

--- a/rover/motor.ino
+++ b/rover/motor.ino
@@ -4,8 +4,9 @@ extern "C" {
     #include "errors.h"
 }
 
-uint8_t motorPin1[] = {9, 7};
-uint8_t motorPin2[] = {8, 6};
+uint8_t enablePin[] = {9, 10};
+uint8_t motorPin1[] = {8, 6};
+uint8_t motorPin2[] = {7, 5};
 
 struct {
   EVT_Event_t event = {EVT_TYPE_MOTOR_SPEED};

--- a/rover/rover.ino
+++ b/rover/rover.ino
@@ -13,8 +13,6 @@ extern "C" {
 #include "events.h"
 #include "errors.h"
 
-uint8_t enablePin[] = {10, 5};
-
 #define LED 13
 
 #define MAX_CMD       64
@@ -30,6 +28,8 @@ EVT_Event_t syncTOEvent = {EVT_TYPE_SYNC_TO};
 EVT_Event_t ciStopEvent = {EVT_TYPE_CI_STOP};
 
 #define TBL_VAL_IMPACT_ENABLE 1
+#define TBL_VAL_MOTOR_BIAS_A  2
+#define TBL_VAL_MOTOR_BIAS_B  3
 
 TO_t to   = {0};
 EVT_t evt = {0};


### PR DESCRIPTION
This PR makes two fixes that resulted in the rover now driving straight ahead.

Stubborn has a tendency to wander...

https://user-images.githubusercontent.com/50074/122506431-329a4a00-cfb3-11eb-8acc-b88ba6b07cd9.mov


I found a helpful article on [Improve Brushed DC Motor Performance](https://learn.adafruit.com/improve-brushed-dc-motor-performance/overview) wherein a stumbled on a very interesting fact: The power cycle for a PWM motor is impacted by the clock speed of the PWM. Even more important, the clock speed can vary by port:

from [the docs](https://www.arduino.cc/reference/en/language/functions/analog-io/analogwrite/):

  > 490 Hz (pins 5 and 6: 980 Hz)

Turns out, one of my enable pins on the motor controller was using pin 6 which means one pin was at 490hz and one was at 980hz. That can't be good.

After swapping some pins around though, Stubborn was still pretty crooked.

So this brings me to the second fix: Adding a bias setting for the motor. Using the newly built `tbl` component I can set, at run time, a value to bias one motor against the other. Drag the one down that's going simply too fast.


<details>
<summary>It only took a couple of tries:</summary>

```
-> SET 2 0
<- [SENT 2]
<- [2 OK]
-> FWD
<- [SENT 3]
<- [3 OK]
-> SET 3 10
<- [SENT 4]
<- [4 OK]
-> FWD
<- [SENT 5]
<- [5 OK]
-> FWD
<- [SENT 6]
<- [6 OK]
-> FWD 50
<- [SENT 7]
<- [7 OK]
-> SET 3 7
<- [SENT 8]
<- [8 OK]
-> FWD 50
<- [SENT 9]
<- [9 OK]
-> SET 3 8
<- [SENT 10]
<- [10 OK]
-> FWD
<- [SENT 11]
<- [11 OK]
-> SET 3 7
<- [SENT 12]
<- [12 OK]
-> FWD
<- [SENT 13]
<- [13 OK]
-> FWD
<- [SENT 14]
<- [14 OK]
-> FWD
<- [SENT 30]
<- [30 OK]
-> FWD 50
<- [SENT 31]
<- [31 OK]
```
</details>

and now...


https://user-images.githubusercontent.com/50074/122506350-01ba1500-cfb3-11eb-9713-6b81e4a91aed.mov

