### PR TITLE
TO: add TO_decode to work around platform differences

### DIFF
--- a/libraries/CiC/src/to.c
+++ b/libraries/CiC/src/to.c
@@ -40,14 +40,37 @@ size_t TO_encode(TO_t *to, uint8_t *buf, size_t size)
             continue;
         }
 
-        if (available < sizeof(TO_Object_t)) {
+        if (available < TO_OBJECT_SIZE) {
             continue;
         }
 
-        memcpy(b, &(to->objects[n]), sizeof(TO_Object_t));
-        b += sizeof(TO_Object_t);
-        available -= sizeof(TO_Object_t);
+        b[0] = to->objects[n].param;
+        memcpy(b+1, &(to->objects[n].data), 4);
+
+        b += TO_OBJECT_SIZE;
+        available -= TO_OBJECT_SIZE;
     }
 
     return b - buf;
+}
+
+int TO_decode(TO_t *to, uint8_t *buf, size_t size)
+{
+    int bn = 0;
+    int n = 0;
+    while (bn+TO_OBJECT_SIZE <= size) {
+        if (n >= TO_MAX_PARAMS) {
+            return -1;
+        }
+
+        to->objects[n].param = buf[bn];
+
+        memcpy((uint8_t *)(&to->objects[n].data), buf+bn+1, 4);
+
+        bn += TO_OBJECT_SIZE;
+
+        n++;
+    }
+
+    return n;
 }

--- a/libraries/CiC/src/to.h
+++ b/libraries/CiC/src/to.h
@@ -21,6 +21,9 @@ typedef struct {
     uint32_t data;
 } TO_Object_t;
 
+// On the wire, this is how large an objects should be.
+#define TO_OBJECT_SIZE 5
+
 /**
  * TO_t Telemetry Output component tracks multiple parameters and provides
  * interfaces for encoding them for transmission.
@@ -61,4 +64,16 @@ int TO_set(TO_t *to, uint8_t param, uint32_t value);
  * @returns size of encoded telemetry data for use in sending through a communication channel.
  */
 size_t TO_encode(TO_t *to, uint8_t *buf, size_t size);
+
+/*
+ * TO_decode decodes the telemetry buffer into a TO_t struct.
+ * 
+ * @param to Pointer to TO_t component.
+ * @param buf Pointer to data buffer
+ * @param size size of data buffer
+ * 
+ * @returns count of decoded objects
+ */
+int TO_decode(TO_t *to, uint8_t *buf, size_t size);
+
 #endif

--- a/libraries/CiC/test/test_to.c
+++ b/libraries/CiC/test/test_to.c
@@ -75,15 +75,18 @@ static char * test_encode() {
     uint8_t *data = malloc(1024);
 
     int encoded = TO_encode(&to, data, 1024);
-    mu_assert("test_encode: wrong size", encoded == sizeof(TO_Object_t)*2);
+    mu_assert("test_encode: wrong size", encoded == TO_OBJECT_SIZE*2);
 
-    TO_Object_t *tobj = (TO_Object_t *)data;
-    mu_assert("test_encode: wrong param", tobj->param == 1);
-    mu_assert("test_encode: wrong value", tobj->data == 42);
+    TO_t to2;
+    TO_init(&to2);
+    int decoded = TO_decode(&to2, data, encoded);
+    mu_assert("test_encode: decoded wrong elements", 2 == decoded);
 
-    tobj++;
-    mu_assert("test_encode: wrong param 2", tobj->param == 2);
-    mu_assert("test_encode: wrong value 2", tobj->data == 1024);
+    mu_assert("test_encode: wrong param", to2.objects[0].param == 1);
+    mu_assert("test_encode: wrong value", to2.objects[0].data == 42);
+
+    mu_assert("test_encode: wrong param 2", to2.objects[1].param == 2);
+    mu_assert("test_encode: wrong value 2", to2.objects[1].data == 1024);
 
     free(data);
 


### PR DESCRIPTION
On an 8-bit machine it was fine to just cast memory to the TO_Object_t, but on other architectures we need to deal with padding. 

A TO_decode function will map the data stream into proper TO_Objects.

I have not updated the existing `ground` to use this new function as it sorta doesn't matter: It's running on an 8-bit Arduino anyway. But the new ground station will need it so I'll be using it there.