### PR TITLE
COM Version 2 - Now with Delayed Replies and auto- Re-transmit behavior

### DIFF
--- a/libraries/CiC/src/com.c
+++ b/libraries/CiC/src/com.c
@@ -16,7 +16,15 @@ static uint8_t encode_header(uint8_t type)
     return COM_VERSION << 4 | type;
 }
 
-int COM_recv(COM_t *com, uint8_t *data, size_t length)
+void COM_init(COM_t *com, EVT_t *evt, TMR_t *tmr)
+{
+    com->evt = evt;
+    com->tmr = tmr;
+    com->recv_at = 0;
+    com->data_len = 0;
+}
+
+int COM_recv(COM_t *com, uint8_t *data, size_t length, unsigned long now)
 {
     uint8_t *payload = data;
     size_t payload_length = length;
@@ -29,6 +37,8 @@ int COM_recv(COM_t *com, uint8_t *data, size_t length)
     if (COM_VERSION != COM_version(frame)) {
         return -1;
     }
+
+    com->recv_at = now;
 
     payload += sizeof(COM_Frame_t);
     payload_length -= sizeof(COM_Frame_t);

--- a/libraries/CiC/src/com.c
+++ b/libraries/CiC/src/com.c
@@ -20,7 +20,9 @@ void COM_init(COM_t *com, EVT_t *evt, TMR_t *tmr)
 {
     com->evt = evt;
     com->tmr = tmr;
-    com->recv_at = 0;
+
+    com->sent_at = 0;
+    com->last_recv_at = 0;
     com->data_len = 0;
 }
 
@@ -38,138 +40,28 @@ int COM_recv(COM_t *com, uint8_t *data, size_t length, unsigned long now)
         return -1;
     }
 
-    com->recv_at = now;
+    com->last_recv_at = now;
 
     payload += sizeof(COM_Frame_t);
     payload_length -= sizeof(COM_Frame_t);
 
-    COM_CI_Event_t   ci_evt;
-    ci_evt.event.type = COM_EVT_TYPE_CI;
-
-    COM_CI_R_Event_t ci_r_evt;
-    ci_r_evt.event.type = COM_EVT_TYPE_CI_R;
-
-    COM_TO_Event_t   to_evt;
-    to_evt.event.type = COM_EVT_TYPE_TO;
-
-    switch (COM_type(frame)) {
-        case COM_TYPE_CI:
-            ci_evt.frame = (COM_CI_Frame_t *)payload;
-            ci_evt.length = length - sizeof(COM_CI_Frame_t);
-            if (ci_evt.length > 0) {
-                ci_evt.data = payload + sizeof(COM_CI_Frame_t);
-            } else {
-                ci_evt.data = NULL;
-            }
-
-            EVT_notify(com->evt, (EVT_Event_t *)&ci_evt);
-            return 0;
-        case COM_TYPE_CI_R:
-            ci_r_evt.frame = (COM_CI_R_Frame_t *)payload;
-            EVT_notify(com->evt, (EVT_Event_t *)&ci_r_evt);
-            return 0;
-        case COM_TYPE_TO:
-            to_evt.data = payload;
-            to_evt.length = payload_length;
-            EVT_notify(com->evt, (EVT_Event_t *)&to_evt);
-            return 0;
+    if (COM_TYPE_REPLY == COM_type(frame) && ntohs(frame->seq_num) == com->seq_num) {
+        com->ack_at = now;
     }
 
-    return -2;
-}
+    COM_Msg_Event_t   msg_evt;
+    msg_evt.event.type = COM_EVT_TYPE_MSG;
+    msg_evt.msg_type = COM_type(frame);
+    msg_evt.seq_num = frame->seq_num;
+    msg_evt.channel = frame->channel;
+    msg_evt.data = payload;
+    msg_evt.length = payload_length;
 
-int COM_send_ci(COM_t *com, uint8_t cmd, uint8_t cmd_num, uint8_t *data, size_t length)
-{
-    COM_Data_Event_t evt;
-    evt.event.type = COM_EVT_TYPE_DATA;
-    evt.data = com->data_buf;
-    evt.length = 0;
-
-    uint8_t *payload = com->data_buf;
-
-    COM_Frame_t *frame = (COM_Frame_t *)payload;
-    frame->header = encode_header(COM_TYPE_CI);
-    evt.length += sizeof(COM_Frame_t);
-    payload += sizeof(COM_Frame_t);
-
-    COM_CI_Frame_t *ci_frame = (COM_CI_Frame_t *)payload;
-    ci_frame->cmd = cmd;
-    ci_frame->cmd_num = cmd_num;
-    evt.length += sizeof(COM_CI_Frame_t);
-    payload += sizeof(COM_CI_Frame_t);
-
-    if (evt.length + length > sizeof(com->data_buf)) {
-        return -1;
-    }
-
-    memcpy(payload, data, length);
-    evt.length += length;
-    payload += length;
-
-    com->data_len = evt.length;
-
-    EVT_notify(com->evt, (EVT_Event_t *)&evt);
-
+    EVT_notify(com->evt, (EVT_Event_t *)&msg_evt);
     return 0;
 }
 
-int COM_send_ci_r(COM_t *com, uint8_t cmd_num, uint8_t result)
-{
-    COM_Data_Event_t evt;
-    evt.event.type = COM_EVT_TYPE_DATA;
-    evt.data = com->data_buf;
-    evt.length = 0;
-
-    uint8_t *payload = com->data_buf;
-
-    COM_Frame_t *frame = (COM_Frame_t *)payload;
-    frame->header = encode_header(COM_TYPE_CI_R);
-    evt.length += sizeof(COM_Frame_t);
-    payload += sizeof(COM_Frame_t);
-
-    COM_CI_R_Frame_t *ci_r_frame = (COM_CI_R_Frame_t *)payload;
-    ci_r_frame->cmd_num = cmd_num;
-    ci_r_frame->result = result;
-    evt.length += sizeof(COM_CI_R_Frame_t);
-    payload += sizeof(COM_CI_R_Frame_t);
-
-    com->data_len = evt.length;
-
-    EVT_notify(com->evt, (EVT_Event_t *)&evt);
-
-    return 0;
-}
-
-int COM_send_to(COM_t *com, uint8_t *data, size_t length)
-{
-    COM_Data_Event_t evt;
-    evt.event.type = COM_EVT_TYPE_DATA;
-    evt.data = com->data_buf;
-    evt.length = 0;
-
-    uint8_t *payload = com->data_buf;
-
-    COM_Frame_t *frame = (COM_Frame_t *)payload;
-    frame->header = encode_header(COM_TYPE_TO);
-    evt.length += sizeof(COM_Frame_t);
-    payload += sizeof(COM_Frame_t);
-
-    if (evt.length + length > sizeof(com->data_buf)) {
-        return -1;
-    }
-
-    memcpy(payload, data, length);
-    evt.length += length;
-    payload += length;
-
-    com->data_len = evt.length;
-
-    EVT_notify(com->evt, (EVT_Event_t *)&evt);
-
-    return 0;
-}
-
-int COM_send_retry(COM_t *com)
+void dispatch_send(COM_t *com, unsigned long now)
 {
     COM_Data_Event_t evt;
     evt.event.type = COM_EVT_TYPE_DATA;
@@ -177,5 +69,72 @@ int COM_send_retry(COM_t *com)
     evt.length = com->data_len;
 
     EVT_notify(com->evt, (EVT_Event_t *)&evt);
+    com->sent_at = now;
+}
+
+
+int COM_send(COM_t *com, uint8_t msg_type, uint8_t channel, uint8_t *data, size_t length, unsigned long now)
+{
+    if (length + sizeof(COM_Frame_t) > sizeof(com->data_buf)) {
+        return -1;
+    }
+
+    // Reset our current send packet
+    com->seq_num++;
+    com->ack_at = 0;
+    com->data_len = 0;
+
+    // and start building a new one
+    uint8_t *payload = com->data_buf;
+
+    COM_Frame_t *frame = (COM_Frame_t *)payload;
+
+    frame->header = encode_header(msg_type);
+    frame->channel = channel;
+    frame->seq_num = htons(com->seq_num);
+
+    com->data_len += sizeof(COM_Frame_t);
+    payload += sizeof(COM_Frame_t);
+
+    memcpy(payload, data, length);
+    com->data_len += length;
+    payload += length;
+
+    dispatch_send(com, now);
+
+    return 0;
+}
+
+int COM_send_reply(COM_t *com, uint8_t channel, uint16_t seq_num, uint8_t *data, size_t length, unsigned long now)
+{
+    if (length + sizeof(COM_Frame_t) > sizeof(com->data_buf)) {
+        return -2;
+    }
+
+    com->data_len = 0;
+
+    uint8_t *payload = com->data_buf;
+
+    COM_Frame_t *frame = (COM_Frame_t *)payload;
+
+    frame->header = encode_header(COM_TYPE_REPLY);
+    frame->channel = channel;
+    frame->seq_num = htons(seq_num);
+
+    com->data_len += sizeof(COM_Frame_t);
+    payload += sizeof(COM_Frame_t);
+
+    memcpy(payload, data, length);
+    com->data_len += length;
+    payload += length;
+
+    dispatch_send(com, now);
+
+    return 0;
+}
+
+int COM_send_retry(COM_t *com, unsigned long now)
+{
+    dispatch_send(com, now);
     return 0;
 }

--- a/libraries/CiC/src/com.h
+++ b/libraries/CiC/src/com.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "evt.h"
+#include "tmr.h"
 
 // Command Ingest
 #define COM_TYPE_CI   1
@@ -40,6 +41,8 @@ typedef struct {
  */
 typedef struct {
     EVT_t   *evt;
+    TMR_t   *tmr;
+    unsigned long recv_at;
     uint8_t data_buf[COM_MAX_LENGTH];
     size_t data_len;
 } COM_t;
@@ -90,6 +93,16 @@ typedef struct {
 // Event to indicate a message of type COM_TYPE_TO has been received.
 #define COM_EVT_TYPE_TO   13 
 
+/*
+ * COM_init initializes the communications structure with the dependencies.
+ *
+ * @param com The COM_t component to initialize.
+ * @param evt The EVT_t subsystem to dispatch events to.
+ * @param tmr The TMR_t subsystem for setting timers.
+ * 
+ */
+void COM_init(COM_t *com, EVT_t *evt, TMR_t *tmr);
+
 /**
  *  COM_recv ingests raw communication data into the com system.
  *
@@ -103,8 +116,9 @@ typedef struct {
  * @param com The COM_t component to use.
  * @param data Pointer to the data buffer.
  * @param length Length of received data.
+ * @param now Current time (milliseconds)
 */
-int COM_recv(COM_t *com, uint8_t *data, size_t length);
+int COM_recv(COM_t *com, uint8_t *data, size_t length, unsigned long now);
 
 /**
  * COM_send_ci builds and emits a communications packet of type COM_TYPE_CI
@@ -118,12 +132,13 @@ int COM_recv(COM_t *com, uint8_t *data, size_t length);
  * @param cmd_num The sequence number for the CI command.
  * @param data Pointer to data for the command.
  * @param length Length of data for the command.
+ * @param now Current time (milliseconds)
  * 
  * @return 0 on ok, -1 on error like insufficent buffer space.
  * 
  * \sa ci.h
  */
-int COM_send_ci(COM_t *com, uint8_t cmd, uint8_t cmd_num, uint8_t *data, size_t length);
+int COM_send_ci(COM_t *com, uint8_t cmd, uint8_t cmd_num, uint8_t *data, size_t length, unsigned long now);
 
 /**
  * COM_send_ci_r builds and emits a communications packet of type COM_TYPE_CI_R
@@ -135,12 +150,13 @@ int COM_send_ci(COM_t *com, uint8_t cmd, uint8_t cmd_num, uint8_t *data, size_t 
  * @param com The COM_t component to use.
  * @param cmd_num The sequence number for the CI command.
  * @param result Result of command operation.
+ * @param now Current time (milliseconds)
  * 
  * @return 0 on ok, -1 on error like insufficent buffer space.
  * 
  * \sa ci.h
  */
-int COM_send_ci_r(COM_t *com, uint8_t cmd_num, uint8_t result);
+int COM_send_ci_r(COM_t *com, uint8_t cmd_num, uint8_t result, unsigned long now);
 
 /**
  * COM_send_to builds and emits a communications packet of type COM_TYPE_TO
@@ -152,13 +168,13 @@ int COM_send_ci_r(COM_t *com, uint8_t cmd_num, uint8_t result);
  * @param com The COM_t component to use.
  * @param data Pointer to data for the command.
  * @param length Length of data for the command.
+ * @param now Current time (milliseconds)
  * 
  * @return 0 on ok, -1 on error like insufficent buffer space.
  * 
  * \sa to.h
  */
 int COM_send_to(COM_t *com, uint8_t *data, size_t length);
-
 
 /**
  * COM_send_retry retries the last sent packet.

--- a/libraries/CiC/src/com.h
+++ b/libraries/CiC/src/com.h
@@ -5,14 +5,14 @@
 #include "evt.h"
 #include "tmr.h"
 
-// Command Ingest
-#define COM_TYPE_CI   1
-// Command Response
-#define COM_TYPE_CI_R 2
-// Telemetry Output
-#define COM_TYPE_TO   3
+// COM has two types of communication patterns:
+//  * Request / Reply - Each request is expected to have a reply
+//  * Broadcast -  No reply expected
+#define COM_TYPE_REQ         1
+#define COM_TYPE_REPLY       2
+#define COM_TYPE_BROADCAST   3
 
-#define COM_VERSION  1
+#define COM_VERSION  2
 
 /*
  * COM_Frame_t is the header frame for all COM messages. 
@@ -21,13 +21,9 @@
  */
 typedef struct {
     uint8_t header;
+    uint8_t channel;
+    uint16_t seq_num;
 } COM_Frame_t;
-
-typedef struct {
-    uint8_t type;
-    uint8_t *data;
-    size_t length;
-} COM_Msg_t;
 
 // Maximum length for the communications buffer. This is set based on how large
 // the physical communication system can send and receive.
@@ -42,11 +38,26 @@ typedef struct {
 typedef struct {
     EVT_t   *evt;
     TMR_t   *tmr;
-    unsigned long recv_at;
-    uint8_t data_buf[COM_MAX_LENGTH];
+
+    uint16_t seq_num;
+
+    // recv_at marks when data was last received from our radio
+    // This is helpful because we need to be friendly with our peers by not sending packets before their radio
+    // is ready.
+    unsigned long last_recv_at;
+
+    // sent_at marks when the current packet was (last) sent. This is helpful for determining when we should 
+    // attempt retries.
+    unsigned long sent_at;
+
+    // ack_at marks when the current packet was acknowledged. This only applies to req/reply.
+    unsigned long ack_at;
+
     size_t data_len;
+    uint8_t data_buf[COM_MAX_LENGTH];
 } COM_t;
 
+/*
 typedef struct {
     uint8_t cmd;
     uint8_t cmd_num;
@@ -75,15 +86,6 @@ typedef struct {
     size_t length;
 } COM_TO_Event_t;
 
-typedef struct {
-    EVT_Event_t event;
-    uint8_t *data;
-    size_t length;
-} COM_Data_Event_t;
-
-// Event to indicate data is available for sending via communications device.
-#define COM_EVT_TYPE_DATA 10
-
 // Event to indicate a message of type COM_TYPE_CI has been received.
 #define COM_EVT_TYPE_CI   11
 
@@ -92,6 +94,27 @@ typedef struct {
 
 // Event to indicate a message of type COM_TYPE_TO has been received.
 #define COM_EVT_TYPE_TO   13 
+*/
+
+// Event to indicate data is available for sending via communications device.
+#define COM_EVT_TYPE_DATA 10
+
+typedef struct {
+    EVT_Event_t event;
+    uint8_t *data;
+    size_t length;
+} COM_Data_Event_t;
+
+#define COM_EVT_TYPE_MSG   11
+
+typedef struct {
+    EVT_Event_t event;
+    uint8_t msg_type;
+    uint8_t channel;
+    uint16_t seq_num;
+    size_t length;
+    uint8_t *data;
+} COM_Msg_Event_t;
 
 /*
  * COM_init initializes the communications structure with the dependencies.
@@ -121,66 +144,37 @@ void COM_init(COM_t *com, EVT_t *evt, TMR_t *tmr);
 int COM_recv(COM_t *com, uint8_t *data, size_t length, unsigned long now);
 
 /**
- * COM_send_ci builds and emits a communications packet of type COM_TYPE_CI
- * (command ingest).
+ * COM_send builds and emits a communications packet
  * 
  * This method uses the internal buffer of the COM_t system which will store
  * the data until completion of the resulting COM_EVT_TYPE_DATA.
  * 
  * @param com The COM_t component to use.
- * @param cmd The type of CI command to encode.
- * @param cmd_num The sequence number for the CI command.
+ * @param msg_type The type of message to send (COM_TYPE_*)
+ * @param channel The channel identifier
  * @param data Pointer to data for the command.
  * @param length Length of data for the command.
  * @param now Current time (milliseconds)
  * 
  * @return 0 on ok, -1 on error like insufficent buffer space.
- * 
- * \sa ci.h
  */
-int COM_send_ci(COM_t *com, uint8_t cmd, uint8_t cmd_num, uint8_t *data, size_t length, unsigned long now);
+int COM_send(COM_t *com, uint8_t msg_type, uint8_t channel, uint8_t *data, size_t length, unsigned long now);
 
 /**
- * COM_send_ci_r builds and emits a communications packet of type COM_TYPE_CI_R
- * (command ingest response).
+ * COM_send_reply builds and emits a communications packet in reply to a request.
  * 
  * This method uses the internal buffer of the COM_t system which will store
  * the data until completion of the resulting COM_EVT_TYPE_DATA.
  * 
  * @param com The COM_t component to use.
- * @param cmd_num The sequence number for the CI command.
- * @param result Result of command operation.
- * @param now Current time (milliseconds)
- * 
- * @return 0 on ok, -1 on error like insufficent buffer space.
- * 
- * \sa ci.h
- */
-int COM_send_ci_r(COM_t *com, uint8_t cmd_num, uint8_t result, unsigned long now);
-
-/**
- * COM_send_to builds and emits a communications packet of type COM_TYPE_TO
- * (telemetry output).
- * 
- * This method uses the internal buffer of the COM_t system which will store
- * the data until completion of the resulting COM_EVT_TYPE_DATA.
- * 
- * @param com The COM_t component to use.
+ * @param channel The channel identifier
+ * @param seq_num The message sequence number to reply to
  * @param data Pointer to data for the command.
  * @param length Length of data for the command.
  * @param now Current time (milliseconds)
  * 
  * @return 0 on ok, -1 on error like insufficent buffer space.
- * 
- * \sa to.h
  */
-int COM_send_to(COM_t *com, uint8_t *data, size_t length);
-
-/**
- * COM_send_retry retries the last sent packet.
- *
- * This is maybe temporary until it's automated? Should it live within COM?
- */
-int COM_send_retry(COM_t *com);
+int COM_send_reply(COM_t *com, uint8_t channel, uint16_t seq_num, uint8_t *data, size_t length, unsigned long now);
 
 #endif

--- a/libraries/CiC/src/com.h
+++ b/libraries/CiC/src/com.h
@@ -5,6 +5,15 @@
 #include "evt.h"
 #include "tmr.h"
 
+#ifndef htons
+// From https://github.com/arduino-libraries/Ethernet/blob/7c32bbe146bbe762093e4f021c3b12d7bf8d1629/src/utility/w5100.h
+// The host order of the Arduino platform is little endian.
+// Sometimes it is desired to convert to big endian (or
+// network order)
+#define htons(x) ( ((( x )&0xFF)<<8) | ((( x )&0xFF00)>>8) )
+#define ntohs(x) htons(x)
+#endif
+
 // COM has two types of communication patterns:
 //  * Request / Reply - Each request is expected to have a reply
 //  * Broadcast -  No reply expected

--- a/libraries/CiC/src/tmr.c
+++ b/libraries/CiC/src/tmr.c
@@ -36,6 +36,7 @@ int TMR_handle(TMR_t *tmr, unsigned long now)
     }
 
     tmr->wake_millis = 0;
+    tmr->now_millis = now;
 
     for (int i = 0; i < TMR_MAX_TIMERS; i++) {
         if (tmr->event_notify[i] == 0) {
@@ -55,4 +56,9 @@ int TMR_handle(TMR_t *tmr, unsigned long now)
     }
 
     return 0;
+}
+
+unsigned long TMR_now(TMR_t *tmr)
+{
+    return tmr->now_millis;
 }

--- a/libraries/CiC/src/tmr.h
+++ b/libraries/CiC/src/tmr.h
@@ -17,6 +17,7 @@
 typedef struct {
    EVT_t   *evt;
 
+   unsigned long now_millis;                    // defines when now is for use by tmr dispatched event handlers;
    unsigned long wake_millis;                   // defines when the next event to be delivereed is scheduled.
    EVT_Event_t * events[TMR_MAX_TIMERS];        // array of events to delivery
    unsigned long event_notify[TMR_MAX_TIMERS];  // array of millisecond notify_at values for each event
@@ -39,5 +40,13 @@ int TMR_enqueue(TMR_t *tmr, EVT_Event_t *e, unsigned long notify_at);
  * @param now Current time (milliseconds)
  */
 int TMR_handle(TMR_t *tmr, unsigned long now);
+
+/**
+ * TMR_now returns the current time as recorded when TMR_handle was called to dispatch an event.
+ * This is useful for handlers who need to enqueue another event or otherwise deal with the current time.
+ *
+ * @param tmr TMR_t instance
+ */
+unsigned long TMR_now(TMR_t *tmr);
 
 #endif

--- a/libraries/CiC/test/test_com.c
+++ b/libraries/CiC/test/test_com.c
@@ -7,49 +7,71 @@
  
 int tests_run = 0;
 
-COM_Data_Event_t *ci_notify_d_event = NULL;
-COM_CI_Event_t *ci_notify_ci_event = NULL;
+COM_Data_Event_t *data_event = NULL;
+COM_Msg_Event_t *msg_event = NULL;
 
-static void test_ci_notify(EVT_Event_t *event)
+static void test_com_notify(EVT_Event_t *event)
 {
     switch (event->type) {
         case COM_EVT_TYPE_DATA:
-            ci_notify_d_event = (COM_Data_Event_t *)event;
+            data_event = (COM_Data_Event_t *)event;
             break;
-        case COM_EVT_TYPE_CI:
-            ci_notify_ci_event = (COM_CI_Event_t *)event;
+        case COM_EVT_TYPE_MSG:
+            msg_event = (COM_Msg_Event_t *)event;
             break;
         default:
             printf("unknown type %d\n", event->type);
     }
 }
 
-static char * test_ci() {
-    EVT_t evt;
+static char * test_req_reply() {
+    EVT_t evt = {0};
     EVT_init(&evt);
 
-    COM_t com;
-    COM_init(&com, &evt, NULL);
+    TMR_t tmr = {0};
+
+    COM_t com = {0};
+    COM_init(&com, &evt, &tmr);
 
     char payload[] = "Hello World";
 
-    EVT_subscribe(&evt, &test_ci_notify);
+    EVT_subscribe(&evt, &test_com_notify);
 
-    int ret = COM_send_ci(&com, 2, 1, (uint8_t *)&payload, sizeof(payload));
-    mu_assert("bad send_ci", ret == 0);
-    mu_assert("notify not successful", ci_notify_d_event != NULL);
+    int ret = COM_send(&com, COM_TYPE_REQ, 1, (uint8_t *)&payload, sizeof(payload), 0);
+    mu_assert("bad send", ret == 0);
+    mu_assert("notify not successful", data_event != NULL);
 
-    mu_assert("length is 0", ci_notify_d_event->length > 0);
-    mu_assert("data is null", ci_notify_d_event->data != NULL);
+    mu_assert("length is 0", data_event->length > 0);
+    mu_assert("data is null", data_event->data != NULL);
 
-    ret = COM_recv(&com, ci_notify_d_event->data, ci_notify_d_event->length, 0);
+    ret = COM_recv(&com, data_event->data, data_event->length, 0);
     mu_assert("bad recv", ret == 0);
 
-    mu_assert("recv not successful", ci_notify_ci_event != NULL);
+    mu_assert("recv not successful", msg_event != NULL);
+    mu_assert("wrong channel", 1 == msg_event->channel);
+
+    data_event = NULL;
+
+    // Send a reply
+    ret = COM_send_reply(&com, msg_event->channel, msg_event->seq_num, (uint8_t *)&payload, sizeof(payload), 0);
+    mu_assert("bad send_reply", ret == 0);
+    mu_assert("notify not successful", data_event != NULL);
+    mu_assert("length is 0", data_event->length > 0);
+    mu_assert("data is null", data_event->data != NULL);
+
+    msg_event = NULL;
+
+    ret = COM_recv(&com, data_event->data, data_event->length, 0);
+    mu_assert("bad recv", ret == 0);
+
+    mu_assert("recv not successful", msg_event != NULL);
+    mu_assert("wrong type", COM_TYPE_REPLY == msg_event->msg_type);
+    mu_assert("wrong channel", 1 == msg_event->channel);
 
     return 0;
 }
 
+/*
 static char * test_delay_send() {
     EVT_t evt = {0};
     EVT_init(&evt);
@@ -77,10 +99,11 @@ static char * test_delay_send() {
 
     return 0;
 }
+*/
 
 
 static char * all_tests() {
-    mu_run_test(test_ci);
+    mu_run_test(test_req_reply);
     return 0;
 }
 

--- a/libraries/CiC/test/test_com.c
+++ b/libraries/CiC/test/test_com.c
@@ -27,9 +27,11 @@ static void test_ci_notify(EVT_Event_t *event)
 static char * test_ci() {
     EVT_t evt;
     EVT_init(&evt);
+
     COM_t com;
+    COM_init(&com, &evt, NULL);
+
     char payload[] = "Hello World";
-    com.evt = &evt;
 
     EVT_subscribe(&evt, &test_ci_notify);
 
@@ -40,7 +42,35 @@ static char * test_ci() {
     mu_assert("length is 0", ci_notify_d_event->length > 0);
     mu_assert("data is null", ci_notify_d_event->data != NULL);
 
-    ret = COM_recv(&com, ci_notify_d_event->data, ci_notify_d_event->length);
+    ret = COM_recv(&com, ci_notify_d_event->data, ci_notify_d_event->length, 0);
+    mu_assert("bad recv", ret == 0);
+
+    mu_assert("recv not successful", ci_notify_ci_event != NULL);
+
+    return 0;
+}
+
+static char * test_delay_send() {
+    EVT_t evt = {0};
+    EVT_init(&evt);
+
+    TMR_t tmr = {0};
+
+    COM_t com = {0};
+    COM_init(&com, &evt, &tmr);
+
+    char payload[] = "Hello World";
+
+    EVT_subscribe(&evt, &test_ci_notify);
+
+    int ret = COM_send_ci(&com, 2, 1, (uint8_t *)&payload, sizeof(payload));
+    mu_assert("bad send_ci", ret == 0);
+    mu_assert("notify not successful", ci_notify_d_event != NULL);
+
+    mu_assert("length is 0", ci_notify_d_event->length > 0);
+    mu_assert("data is null", ci_notify_d_event->data != NULL);
+
+    ret = COM_recv(&com, ci_notify_d_event->data, ci_notify_d_event->length, 0);
     mu_assert("bad recv", ret == 0);
 
     mu_assert("recv not successful", ci_notify_ci_event != NULL);

--- a/libraries/CiC/test/test_com.c
+++ b/libraries/CiC/test/test_com.c
@@ -67,11 +67,11 @@ static char * test_req_reply() {
     mu_assert("recv not successful", msg_event != NULL);
     mu_assert("wrong type", COM_TYPE_REPLY == msg_event->msg_type);
     mu_assert("wrong channel", 1 == msg_event->channel);
+    mu_assert("still waiting", 0 == com.data_len);
 
     return 0;
 }
 
-/*
 static char * test_delay_send() {
     EVT_t evt = {0};
     EVT_init(&evt);
@@ -83,27 +83,39 @@ static char * test_delay_send() {
 
     char payload[] = "Hello World";
 
-    EVT_subscribe(&evt, &test_ci_notify);
+    EVT_subscribe(&evt, &test_com_notify);
 
-    int ret = COM_send_ci(&com, 2, 1, (uint8_t *)&payload, sizeof(payload));
-    mu_assert("bad send_ci", ret == 0);
-    mu_assert("notify not successful", ci_notify_d_event != NULL);
+    int ret = COM_send(&com, COM_TYPE_REQ, 1, (uint8_t *)&payload, sizeof(payload), 1);
+    mu_assert("bad send", ret == 0);
+    mu_assert("notify not successful", data_event != NULL);
 
-    mu_assert("length is 0", ci_notify_d_event->length > 0);
-    mu_assert("data is null", ci_notify_d_event->data != NULL);
-
-    ret = COM_recv(&com, ci_notify_d_event->data, ci_notify_d_event->length, 0);
+    ret = COM_recv(&com, data_event->data, data_event->length, 2);
     mu_assert("bad recv", ret == 0);
 
-    mu_assert("recv not successful", ci_notify_ci_event != NULL);
+    data_event = NULL;
+
+    // Send a reply, but it will be delayed
+    ret = COM_send_reply(&com, msg_event->channel, msg_event->seq_num, (uint8_t *)&payload, sizeof(payload), 2);
+    mu_assert("bad send_reply", ret == 0);
+    mu_assert("notify not delayed", data_event == NULL);
+
+    tmr.now_millis = 3;
+    COM_notify((EVT_Event_t *)&(com.dispatch_event));
+
+    mu_assert("notify too soon", data_event == NULL);
+
+    tmr.now_millis = COM_SEND_DELAY+3;
+    COM_notify((EVT_Event_t *)&(com.dispatch_event));
+
+    mu_assert("notify too soon", data_event != NULL);
 
     return 0;
 }
-*/
 
 
 static char * all_tests() {
     mu_run_test(test_req_reply);
+    mu_run_test(test_delay_send);
     return 0;
 }
 

--- a/rover/rfm.ino
+++ b/rover/rfm.ino
@@ -79,7 +79,7 @@ void handleRFMReady(EVT_Event_t *e)
     Serial.println();
 */
 
-    COM_recv(&com, rf_buf, n);
+    COM_recv(&com, rf_buf, n, millis());
 
     if (0 != TO_set(&to, TO_PARAM_RFM_RSSI, (uint8_t)rf69.lastRssi())) {
       Error(ERR_TO_SET);

--- a/rover/rover.ino
+++ b/rover/rover.ino
@@ -70,6 +70,7 @@ void setup() {
   rfmInit();
   motorInit();
 
+  EVT_subscribe(&evt, &COM_notify);
   EVT_subscribe(&evt, &com_ci_notify);
   EVT_subscribe(&evt, &handleSyncTO);
   EVT_subscribe(&evt, &handleCIStop);


### PR DESCRIPTION
Moving from a Arduino Uno-based ground station has brought many challenges. One of them is how difficult it is to get good performance out of the RFM69 transmitter being used for communication.

On a Raspberry Pi, the available code for the RFM69 is all in user-space and has no access to interrupts. This means polling. Even though the RPi is more powerful than an Arduino Uno on just about every axis, the lack of interrupts means the communications is slower. Specifically, it takes time to send a message and then put the device into receive mode to catch the reply.

This PR introduces the concept of "delayed sending" where we can model this delay inside COM by keeping track of when we received a message and waiting (in this case 500ms) before sending a reply. Rather than put this on the client or Mission code it's a built-in feature of COM.

Now that we effectively have a transmit buffer, retries can also be built into the COM system rather than the previous hybrid CI/COM mess I introduced previously. Now we have communications patterns where the client can choose to work with Request/Reply or Broadcast.