### PR TITLE
avoid clobbering send buffer

### DIFF
--- a/libraries/CiC/src/com.c
+++ b/libraries/CiC/src/com.c
@@ -110,6 +110,10 @@ int COM_send(COM_t *com, uint8_t msg_type, uint8_t channel, uint8_t *data, size_
         return -1;
     }
 
+    if (0 != com->data_len) {
+        return -2;
+    }
+
     // Reset our current send packet
     com->seq_num++;
     com->data_len = 0;
@@ -139,6 +143,10 @@ int COM_send(COM_t *com, uint8_t msg_type, uint8_t channel, uint8_t *data, size_
 int COM_send_reply(COM_t *com, uint8_t channel, uint16_t seq_num, uint8_t *data, size_t length, unsigned long now)
 {
     if (length + sizeof(COM_Frame_t) > sizeof(com->data_buf)) {
+        return -1;
+    }
+
+    if (0 != com->data_len) {
         return -2;
     }
 

--- a/rover/rover.ino
+++ b/rover/rover.ino
@@ -199,7 +199,9 @@ void syncTO()
     uint8_t to_buf[MAX_TO_SIZE];
     size_t to_size = TO_encode(&to, to_buf, sizeof(to_buf));
     if (0 < to_size) {
-      if (0 != COM_send(&com, COM_TYPE_BROADCAST, COM_CHANNEL_TO, to_buf, to_size, millis())) {
+      int ret = COM_send(&com, COM_TYPE_BROADCAST, COM_CHANNEL_TO, to_buf, to_size, millis());
+      // No sense complaining about send buffer being full, just wait for the next round.
+      if (0 > ret && -2 != ret) {
         Error(ERR_COM_SEND);
       }
     }


### PR DESCRIPTION
Sending a TO broadcast ever second while maintaining a send delay of 500ms means it's very likely that a REPLY will get clobbered by the next TO send prior to getting sent out. This manifests as really poor communication as it means our requests to the rover do not get answered.

This PR causes `COM_send` to fail if the outgoing buffer is still full.

Long term I'd like to move to a model where each COM channel has its own buffer. For now, this is a pretty easy fix that only results in occasional missed telemetry.